### PR TITLE
fix: raise minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.16)
 
 project(dde-wloutput-daemon)
 


### PR DESCRIPTION
Suppresses warnings: `Your project should require at least CMake 3.16.0 to use FindWayland.cmake`